### PR TITLE
Make the user creation work with a fixed throughput

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -1,7 +1,7 @@
 # Total steps
 total_steps = 2
 # Users to be created per step
-users_per_step = 300
+users_per_step = 100
 # Friendhips (rooms) based on: total possible friendships * friendship ratio
 friendship_ratio = 0.1
 # Step duration where users interact each other
@@ -14,3 +14,7 @@ waiting_period = 30
 retry_request_config = false
 # User creation retry attempts (not related to retry_request_config)
 user_creation_retry_attempts = 5
+# Max throughput allowed for users registration 
+user_creation_throughput = 10
+# Max throughput allowed for room creation 
+room_creation_throughput = 20

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,23 +264,22 @@ fn join_users_to_room(
     first_user: &User<Synching>,
     second_user: &User<Synching>,
     progress_bar: &ProgressBar,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn({
-        let mut first_user = first_user.clone();
-        let mut second_user = second_user.clone();
-        let progress_bar = progress_bar.clone();
+) {
+    let mut first_user = first_user.clone();
+    let mut second_user = second_user.clone();
+    let progress_bar = progress_bar.clone();
 
-        async move {
-            let room_created = first_user.create_room().await;
-            if let Some(room_id) = room_created {
-                first_user.join_room(&room_id).await;
-                second_user.join_room(&room_id).await;
-            } else {
-                log::info!("User {} couldn't create a room", first_user.id());
-            }
-            progress_bar.inc(1);
+    async move {
+        let room_created = first_user.create_room().await;
+        if let Some(room_id) = room_created {
+            first_user.join_room(&room_id).await;
+            second_user.join_room(&room_id).await;
+        } else {
+            //TODO!: This should panic or abort somehow after exhausting all retries of creating the room
+            log::info!("User {} couldn't create a room", first_user.id());
         }
-    })
+        progress_bar.inc(1);
+    }
 }
 
 fn create_user(
@@ -308,6 +307,8 @@ fn create_user(
                 }
             }
         }
+
+        //TODO!: This should panic or abort somehow after exhausting all retries of creating the user
         log::info!("Couldn't init a user");
         progress_bar.inc(1);
         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ fn join_users_to_room(
     first_user: &User<Synching>,
     second_user: &User<Synching>,
     progress_bar: &ProgressBar,
-) {
+) -> impl futures::Future<Output = ()> {
     let mut first_user = first_user.clone();
     let mut second_user = second_user.clone();
     let progress_bar = progress_bar.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,14 +79,12 @@ impl State {
         );
         progress_bar.tick();
 
-        let range = (actual_users..desired_users).collect::<Vec<usize>>();
-
-        let futures = range.iter().map(|i| {
+        let futures = (actual_users..desired_users).map(|i| {
             create_user(
                 server.clone(),
                 &progress_bar,
                 self.metrics.clone(),
-                *i,
+                i,
                 retry_attempts,
                 timestamp,
                 retry_enabled,


### PR DESCRIPTION
As part of #6 this will help create users without asphyxiating the server