### PR TITLE
refactor: use mpsc channel for events and metrics

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -2,7 +2,7 @@
 total_steps = 2
 # Users to be created per step
 users_per_step = 100
-# Friendhips (rooms) based on: total possible friendships * friendship ratio
+# Friendships (rooms) based on: total possible friendships * friendship ratio
 friendship_ratio = 0.1
 # Step duration where users interact each other
 step_duration_in_secs = 30

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,11 @@
+use crate::user::UserRequest;
+use matrix_sdk::HttpError;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub enum Event {
+    Error((UserRequest, HttpError)),
+    MessageSent(String),
+    MessageReceived(String),
+    RequestDuration((UserRequest, Duration)),
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -8,4 +8,6 @@ pub enum Event {
     MessageSent(String),
     MessageReceived(String),
     RequestDuration((UserRequest, Duration)),
+    AllMessagesSent,
+    Finish,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,13 @@ use std::thread::sleep;
 use std::time::{Duration, Instant};
 use text::create_progress_bar;
 use time::time_now;
+use tokio::sync::mpsc::Sender;
 use tokio::time::interval;
 use user::{Synching, User};
 
+use crate::events::Event;
+
+mod events;
 mod friendship;
 mod metrics;
 mod text;
@@ -39,7 +43,6 @@ pub struct State {
     config: Configuration,
     friendships: Vec<Friendship>,
     users: Vec<User<Synching>>,
-    metrics: Metrics,
 }
 
 impl Display for State {
@@ -61,11 +64,10 @@ impl State {
             config,
             friendships: vec![],
             users: vec![],
-            metrics: Metrics::default(),
         }
     }
 
-    async fn init_users(&mut self) {
+    async fn init_users(&mut self, tx: Sender<Event>) {
         let timestamp = time_now();
         let actual_users = self.users.len();
         let desired_users = actual_users + self.config.users_per_step;
@@ -83,7 +85,7 @@ impl State {
             create_user(
                 server.clone(),
                 &progress_bar,
-                self.metrics.clone(),
+                tx.clone(),
                 i,
                 retry_attempts,
                 timestamp,
@@ -196,7 +198,7 @@ impl State {
         progress_bar.finish_and_clear();
     }
 
-    async fn waiting_period(&self) {
+    async fn waiting_period(&self, metrics: &Metrics) {
         let spinner = ProgressBar::new_spinner()
             .with_style(
                 ProgressStyle::default_spinner()
@@ -208,21 +210,16 @@ impl State {
         let waiting_time = Duration::from_secs(self.config.waiting_period as u64);
         let one_sec = Duration::from_secs(1);
         let start = Instant::now();
-
-        while !self.metrics.all_messages_received() {
+        while !metrics.all_messages_received().await {
             if start.elapsed().ge(&waiting_time) {
-                // waiting time finished, finishing step
                 break;
             }
-
             let wait_one_sec = Instant::now();
             spinner.set_message("Waiting for messages...");
             loop {
                 if wait_one_sec.elapsed().ge(&one_sec) {
-                    // waiting time finished, finishing step
                     break;
                 }
-
                 sleep(Duration::from_millis(100));
                 spinner.inc(1);
             }
@@ -236,21 +233,23 @@ impl State {
 
         let execution_id = time_now();
 
+        let (metrics, tx) = Metrics::new();
         for step in 1..=self.config.total_steps {
             println!("Running step {}", step);
 
             // step warm up
-            self.init_users().await;
+            self.init_users(tx.clone()).await;
             self.init_friendships().await;
 
             // step running
             self.act().await;
-            self.waiting_period().await;
+            self.waiting_period(&metrics).await;
 
             println!("{}", self);
 
-            self.metrics
-                .generate_report(execution_id, step, &self.config.output_dir);
+            metrics
+                .generate_report(execution_id, step, &self.config.output_dir)
+                .await;
 
             // print new line in between steps
             if step < self.config.total_steps {
@@ -285,7 +284,7 @@ fn join_users_to_room(
 fn create_user(
     server: String,
     progress_bar: &ProgressBar,
-    metrics: Metrics,
+    tx: Sender<Event>,
     i: usize,
     retry_attempts: usize,
     timestamp: u128,
@@ -295,7 +294,7 @@ fn create_user(
     async move {
         let id = format!("user_{i}_{timestamp}");
         for _ in 0..retry_attempts {
-            let user = User::new(&id, &server, retry_enabled, metrics.clone()).await;
+            let user = User::new(&id, &server, retry_enabled, tx.clone()).await;
 
             if let Some(mut user) = user {
                 if let Some(mut user) = user.register().await {


### PR DESCRIPTION
## Description

Use multi producers single consumer channel to comunicate events. It spawns a task for the receiver to read the channel in parallel.
