### PR TITLE
feat: add timeout to user interactions per tick

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "tokio",
+ "tokio-context",
 ]
 
 [[package]]
@@ -2505,6 +2506,15 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-context"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf0b8394dd5ca9a1b726c629390154c19222dfd7467a4b56f1ced90adee3958"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 rand = "0.8.5"
 tokio = { version = "1", features = ["full"] }
+tokio-context = "0.1.3"
 lipsum = "0.8.0"
 futures = "0.3.21"
 log = "0.4.16"

--- a/Config.toml
+++ b/Config.toml
@@ -4,9 +4,11 @@ total_steps = 2
 users_per_step = 100
 # Friendships (rooms) based on: total possible friendships * friendship ratio
 friendship_ratio = 0.1
-# Step duration where users interact each other
+# Step total duration
 step_duration_in_secs = 30
-# Max users to act per second during a step
+# Tick duration where users interact each other
+tick_duration_in_secs = 5
+# Max users to act per tick during a step
 max_users_to_act_per_tick = 100
 # Time to wait for all messages to be delivered, after that time they are considered as lost
 waiting_period = 30

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@ pub struct Configuration {
     total_steps: usize,
     users_per_step: usize,
     friendship_ratio: f32,
-    step_duration_in_secs: usize,
+    step_duration_in_secs: u64,
+    tick_duration_in_secs: u64,
     max_users_to_act_per_tick: usize,
     waiting_period: usize,
     retry_request_config: bool,
@@ -49,10 +50,6 @@ impl Display for State {
     fn fmt(&self, w: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(w, "Amount of users: {}", self.users.len()).unwrap();
         writeln!(w, "Amount of friendships: {}", self.friendships.len()).unwrap();
-        writeln!(w, "Listing friendships: ").unwrap();
-        for friendship in &self.friendships {
-            writeln!(w, "- {}", friendship).unwrap();
-        }
 
         Ok(())
     }
@@ -160,40 +157,57 @@ impl State {
 
     async fn act(&mut self, tx: Sender<Event>) {
         let start = Instant::now();
-        let step_secs = self.config.step_duration_in_secs;
-        let step_duration = Duration::from_secs(step_secs as u64);
+
+        let step_duration = Duration::from_secs(self.config.step_duration_in_secs);
+        let tick_duration = Duration::from_secs(self.config.tick_duration_in_secs);
 
         let users_to_act = std::cmp::min(self.users.len(), self.config.max_users_to_act_per_tick);
         let progress_bar = create_progress_bar(
-            "Running".to_string(),
-            (step_secs * users_to_act).try_into().unwrap(),
+            "Running",
+            (step_duration.as_secs_f64() / tick_duration.as_secs_f64()).ceil() as u64,
         );
-        progress_bar.tick();
 
-        let mut one_sec_interval = interval(Duration::from_secs(1));
+        progress_bar.tick();
         let mut rng = rand::thread_rng();
         loop {
             if start.elapsed().ge(&step_duration) {
                 // elapsed time for current step reached, breaking the loop and proceed to next step
                 break;
             }
-            let mut handles = vec![];
+            let loop_start = Instant::now();
 
+            let mut handles = vec![];
             for user in self.users.iter().choose_multiple(&mut rng, users_to_act) {
-                let user = user;
                 handles.push(tokio::spawn({
                     let mut user = user.clone();
-                    let progress_bar = progress_bar.clone();
                     async move {
                         user.act().await;
-                        progress_bar.inc(1);
                     }
                 }));
             }
-            join_all(handles).await;
 
-            // waits for a second before the next iteration
-            one_sec_interval.tick().await;
+            tokio::select! {
+                _ = abort_after(tick_duration) => {
+                    log::info!("it took more than 5 seconds to send all messages: {} ms", loop_start.elapsed().as_millis());
+                }
+                _ = join_all(handles) => {
+                    log::info!("time to send {} messages: {} ms", users_to_act, loop_start.elapsed().as_millis());
+
+                    println!("time to send {} messages: {} ms", users_to_act, loop_start.elapsed().as_millis());
+                }
+            }
+
+            let elapsed = loop_start.elapsed();
+            if elapsed.le(&tick_duration) {
+                println!(
+                    "tick ended in {} ms, waiting {} ms to complete tick duration",
+                    elapsed.as_millis(),
+                    (tick_duration - elapsed).as_millis()
+                );
+                println!();
+                sleep(tick_duration - elapsed);
+            }
+            progress_bar.inc(1);
         }
         progress_bar.finish_and_clear();
 
@@ -320,4 +334,10 @@ fn create_user(
         progress_bar.inc(1);
         None
     }
+}
+
+async fn abort_after(duration: Duration) {
+    let mut interval = interval(duration);
+    interval.tick().await; // the first tick completes immediately.
+    interval.tick().await;
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,6 +31,7 @@ pub struct Report {
     requests_average_time: Vec<(UserRequest, u128)>,
     http_errors_per_request: Vec<(String, usize)>,
     message_delivery_average_time: u128,
+    messages_sent: usize,
     lost_messages: usize,
 }
 
@@ -48,11 +49,16 @@ impl Report {
         http_errors_per_request.sort_unstable_by_key(|(_, count)| Reverse(*count));
 
         let lost_messages = calculate_lost_messages(messages);
+        let messages_sent = messages
+            .iter()
+            .filter(|(_, times)| times.sent.is_some())
+            .count();
 
         Self {
             requests_average_time,
             http_errors_per_request,
             message_delivery_average_time,
+            messages_sent,
             lost_messages,
         }
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use indicatif::{ProgressBar, ProgressStyle};
 use lipsum::lipsum;
 use rand::Rng;
@@ -7,7 +9,7 @@ pub fn get_random_string() -> String {
     lipsum(random_number)
 }
 
-pub fn create_progress_bar(text: String, size: u64) -> ProgressBar {
+pub fn create_progress_bar(text: impl Into<Cow<'static, str>>, size: u64) -> ProgressBar {
     let progress_style = ProgressStyle::default_bar()
         .template("{prefix:>12.cyan.bold}: [{bar:57}] {pos}/{len}")
         .progress_chars("=> ");


### PR DESCRIPTION
## Description

Adds the concept of tick duration. On every step, on every tick, users act sending messages. With these changes we ensure those interactions happen during the tick, otherwise they will be cancelled.

Also it adds a metric of total messages sent to the report.

### Extra
- reverted the exception when there is no room joined as it often happens (to be reviewed)