### PR TITLE
chore: add config to respect login well known

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -20,3 +20,6 @@ user_creation_retry_attempts = 5
 user_creation_throughput = 10
 # Max throughput allowed for room creation 
 room_creation_throughput = 20
+# Update the client's homeserver URL with the discovery information present in the login response, if any.
+# In case of localhost, you probably want to set as false.
+respect_login_well_known = true


### PR DESCRIPTION
## Description 

Adds `respect_login_well_known` config to determine if it should update the client's homeserver URL with the discovery information present in the login response, if any.

It is helpful for cases where the matrix instance (like localhost) doesn't provide correct discovery information.

Resolves #11