### PR TITLE
fix: continue creation, consuming buffer of events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
-name = "matrix-load-testing-tool"
-version = "0.1.0"
 description = "Matrix load testing tool"
-repository = "https://github.com/decentraland/matrix-load-testing-tool"
 edition = "2021"
+name = "matrix-load-testing-tool"
+repository = "https://github.com/decentraland/matrix-load-testing-tool"
+version = "0.1.0"
 
 [dependencies]
-rand = "0.8.5"
-tokio = { version = "1", features = ["full"] }
-tokio-context = "0.1.3"
-lipsum = "0.8.0"
-futures = "0.3.21"
-log = "0.4.16"
-env_logger = "0.9.0"
-indicatif = "0.16.2"
-serde = "1.0.136"
-serde_yaml = "0.8.23"
-serde_with = "1.12.1"
-strum = { version = "0.21", features = ["derive"] }
-clap = { version = "3.1.8", features = ["derive"] }
+clap = {version = "3.1.8", features = ["derive"]}
 config = "0.13"
+env_logger = "0.9.0"
+futures = "0.3.21"
+indicatif = "0.16.2"
+lipsum = "0.8.0"
+log = "0.4.16"
+rand = "0.8.5"
 regex = "1"
+serde = "1.0.136"
+serde_with = "1.12.1"
+serde_yaml = "0.8.23"
+strum = {version = "0.21", features = ["derive"]}
+tokio = {version = "1", features = ["full"]}
+tokio-context = "0.1.3"
 
 [dependencies.matrix-sdk]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
@@ -29,3 +29,23 @@ rev = "35f598a"
 [lib]
 name = "matrix_load_testing_tool"
 path = "src/lib.rs"
+
+# On Windows
+# ```
+# cargo install -f cargo-binutils
+# rustup component add llvm-tools-preview
+# ```
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+[target.x86_64-pc-windows-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+# On Linux:
+# - Ubuntu, `sudo apt-get install lld clang`
+# - Arch, `sudo pacman -S lld clang`
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
+# On MacOS, `brew install michaeleisel/zld/zld`
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"]
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"]

--- a/Config.toml.example
+++ b/Config.toml.example
@@ -23,3 +23,5 @@ room_creation_throughput = 20
 # Update the client's homeserver URL with the discovery information present in the login response, if any.
 # In case of localhost, you probably want to set as false.
 respect_login_well_known = true
+# Count of useres to work with (create/erase)
+user_count = 3000

--- a/README.md
+++ b/README.md
@@ -1,76 +1,62 @@
 # Matrix Load Testing Tool
 
-## Quick start:
+## Setup
 
-Run this command specifying the Matrix instance to be tested for the `homeserver` argument:
+Before running the commands below remember to install the linker used by your OS:
+#### On Windows
+```
+ cargo install -f cargo-binutils
+ rustup component add llvm-tools-preview
+```
+#### On Linux:
+- Ubuntu, `sudo apt-get install lld clang`
+- Arch, `sudo pacman -S lld clang`
+#### On MacOS
+```brew install michaeleisel/zld/zld```
 
-```bash
-cargo run --release -- --homeserver HOST
+## Quick start
+
+1. First of all, copy the `Config.toml.example` file in the root directory of the project to `Config.toml`, this file will be ignored in the git repository.
+
+1. Make sure users are available for the server you will be testing by checking the (`users.json`)[users.json] file, or create them by running:
+
+```
+cargo run --release -- --create --amount NUMBER_OF_USERS_TO_CREATE --homeserver HOST
 ```
 
-### Sample results:
+1. Run this command specifying the Matrix instance to be tested for the `homeserver` argument:
 
 ```bash
-$ cargo run --release -- --homeserver DEV_SERVER_HOST
-   Compiling matrix-load-testing-tool v0.1.0 ($PATH_TO_REPO/matrix-load-testing-tool)
-    Finished release [optimized] target(s) in 50.21s
-     Running `target/release/matrix-load-testing-tool --homeserver DEV_SERVER_HOST`
-Configuration {
-    homeserver_url: "DEV_SERVER_HOST",
-    output_dir: "output",
-    total_steps: 2,
-    users_per_step: 10,
-    friendship_ratio: 0.1,
-    step_duration_in_secs: 30,
-    max_users_to_act_per_tick: 100,
-    waiting_period: 30,
-    retry_request_config: false,
-    user_creation_retry_attempts: 5,
-}
-
-Running step 1
-Amount of users: 10
-Amount of friendships: 5
-Listing friendships:
-- @user_0_1649967588280-user_8_1649967588280:DEV_SERVER_HOST
-- @user_1_1649967588280-user_4_1649967588280:DEV_SERVER_HOST
-- @user_2_1649967588280-user_5_1649967588280:DEV_SERVER_HOST
-- @user_3_1649967588280-user_5_1649967588280:DEV_SERVER_HOST
-- @user_7_1649967588280-user_8_1649967588280:DEV_SERVER_HOST
-
-Report generated: output/1649967625850/report_1_1649967625871.yaml
-
-Running step 2
-Amount of users: 20
-Amount of friendships: 19
-Listing friendships:
-- @user_0_1649967588280-user_3_1649967588280:DEV_SERVER_HOST
-- @user_0_1649967588280-user_8_1649967588280:DEV_SERVER_HOST
-- @user_1_1649967588280-user_4_1649967588280:DEV_SERVER_HOST
-- @user_2_1649967588280-user_5_1649967588280:DEV_SERVER_HOST
-- @user_2_1649967588280-user_9_1649967588280:DEV_SERVER_HOST
-- @user_3_1649967588280-user_5_1649967588280:DEV_SERVER_HOST
-- @user_5_1649967588280-user_6_1649967588280:DEV_SERVER_HOST
-- @user_7_1649967588280-user_8_1649967588280:DEV_SERVER_HOST
-- @user_10_1649967625877-user_1_1649967588280:DEV_SERVER_HOST
-- @user_11_1649967625877-user_19_1649967625877:DEV_SERVER_HOST
-- @user_11_1649967625877-user_7_1649967588280:DEV_SERVER_HOST
-- @user_12_1649967625877-user_7_1649967588280:DEV_SERVER_HOST
-- @user_14_1649967625877-user_8_1649967588280:DEV_SERVER_HOST
-- @user_15_1649967625877-user_1_1649967588280:DEV_SERVER_HOST
-- @user_15_1649967625877-user_2_1649967588280:DEV_SERVER_HOST
-- @user_16_1649967625877-user_1_1649967588280:DEV_SERVER_HOST
-- @user_16_1649967625877-user_2_1649967588280:DEV_SERVER_HOST
-- @user_17_1649967625877-user_1_1649967588280:DEV_SERVER_HOST
-- @user_17_1649967625877-user_6_1649967588280:DEV_SERVER_HOST
-
-Report generated: output/1649967625850/report_2_1649967665309.yaml
+cargo run --release -- --run --homeserver HOST
 ```
 
-For more options and parameters to be configured please see `cargo run -- --help` and the [Config.toml](/Config.toml).
+### Sample results
+
+After running the test, a directory with the current run will be created with a file report for each step with the following data:
+
+```yaml
+---
+homeserver: synapse.decentraland.io
+step: 1
+step_users: 20
+step_friendships: 19
+report:
+  requests_average_time:
+    create_room: 4128
+    login: 2160
+    send_message: 471
+    join_room: 331
+  http_errors_per_request: {}
+  message_delivery_average_time: 54
+  messages_sent: 96
+  lost_messages: 0
+
+```
+
+For more options and parameters to be configured please see `cargo run -- --help` and the [Config.toml.example](/Config.toml.example).
 
 
 
-## Contact me:
+## Contact me
 
 dservices+matrix-load-testing-tool@decentraland.org

--- a/README.md
+++ b/README.md
@@ -3,40 +3,56 @@
 ## Setup
 
 Before running the commands below remember to install the linker used by your OS:
-#### On Windows
+
+### On Windows:
+
 ```
- cargo install -f cargo-binutils
- rustup component add llvm-tools-preview
+cargo install -f cargo-binutils
+rustup component add llvm-tools-preview
 ```
-#### On Linux:
-- Ubuntu, `sudo apt-get install lld clang`
-- Arch, `sudo pacman -S lld clang`
-#### On MacOS
-```brew install michaeleisel/zld/zld```
+
+### On Linux:
+
+- Ubuntu
+
+  ```bash
+  sudo apt-get install lld clang
+  ```
+
+- Arch
+  ```bash
+  sudo pacman -S lld clang
+  ```
+
+### On MacOS:
+
+```bash
+brew install michaeleisel/zld/zld
+```
 
 ## Quick start
 
-1. First of all, copy the `Config.toml.example` file in the root directory of the project to `Config.toml`, this file will be ignored in the git repository.
+1. First of all, copy the [`Config.toml.example`](Config.toml.example) file in the root directory of the project to `Config.toml`, this file will be ignored in the git repository.
 
-1. Make sure users are available for the server you will be testing by checking the (`users.json`)[users.json] file, or create them by running:
+1. Make sure users are available for the server you will be testing by checking the [`users.json`](users.json) file, or create them by running:
 
-```
-cargo run --release -- --create --amount NUMBER_OF_USERS_TO_CREATE --homeserver HOST
-```
+   ```
+   cargo run --release -- --create --amount NUMBER_OF_USERS_TO_CREATE --homeserver HOST
+   ```
 
 1. Run this command specifying the Matrix instance to be tested for the `homeserver` argument:
 
-```bash
-cargo run --release -- --run --homeserver HOST
-```
+   ```bash
+   cargo run --release -- --run --homeserver HOST
+   ```
 
 ### Sample results
 
-After running the test, a directory with the current run will be created with a file report for each step with the following data:
+After running the test, a directory with the current run will be created in the output directory (`output/{timestamp}` by default) with a file report for each step (e.g. `output/1650978209761/report_1_1650978284466.yaml`) with the following data:
 
 ```yaml
 ---
-homeserver: synapse.decentraland.io
+homeserver: HOMESERVER_URL
 step: 1
 step_users: 20
 step_friendships: 19
@@ -50,12 +66,9 @@ report:
   message_delivery_average_time: 54
   messages_sent: 96
   lost_messages: 0
-
 ```
 
 For more options and parameters to be configured please see `cargo run -- --help` and the [Config.toml.example](/Config.toml.example).
-
-
 
 ## Contact me
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,17 +326,19 @@ impl State {
     pub async fn create_users(&mut self) {
         let (tx, rx) = mpsc::channel::<Event>(100);
         let metrics = Metrics::new(rx);
-        let _handle = metrics.run();
+        let handle = metrics.run();
+
         create_desired_users(&self.config, tx.clone()).await;
-        // let report = handle.await.expect("read events loop should end correctly");
-        // log::error!(
-        //     "Create users command finished {} errors",
-        //     if report.any_error() {
-        //         "with"
-        //     } else {
-        //         "without"
-        //     }
-        // )
+
+        let report = handle.await.expect("read events loop should end correctly");
+        println!(
+            "Create users command finished {} errors",
+            if report.any_error() {
+                "with"
+            } else {
+                "without"
+            }
+        )
     }
 
     pub fn generate_report(&self, execution_id: u128, step: usize, report: MetricsReport) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ impl State {
         let server = config.homeserver_url.clone();
 
         let saved_users = load_users(config.users_filename.clone());
-        let _available_users = saved_users.get_available_users(server);
+        let _available_users = saved_users.get_available_users(&server);
 
         let users_state = match _available_users {
             Some(val) => SavedUserState {
@@ -324,8 +324,19 @@ impl State {
     }
 
     pub async fn create_users(&mut self) {
-        let (tx, _rx) = mpsc::channel::<Event>(100);
+        let (tx, rx) = mpsc::channel::<Event>(100);
+        let metrics = Metrics::new(rx);
+        let _handle = metrics.run();
         create_desired_users(&self.config, tx.clone()).await;
+        // let report = handle.await.expect("read events loop should end correctly");
+        // log::error!(
+        //     "Create users command finished {} errors",
+        //     if report.any_error() {
+        //         "with"
+        //     } else {
+        //         "without"
+        //     }
+        // )
     }
 
     pub fn generate_report(&self, execution_id: u128, step: usize, report: MetricsReport) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,7 +34,7 @@ pub struct MetricsReport {
     requests_average_time: Vec<(UserRequest, u128)>,
     #[serde_as(as = "HashMap<DisplayFromStr, _>")]
     http_errors_per_request: Vec<(String, usize)>,
-    message_delivery_average_time: u128,
+    message_delivery_average_time: Option<u128>,
     messages_sent: usize,
     lost_messages: usize,
 }
@@ -196,7 +196,13 @@ fn calculate_requests_average_time(
         .collect()
 }
 
-fn calculate_message_delivery_average_time(messages: &HashMap<String, MessageTimes>) -> u128 {
+fn calculate_message_delivery_average_time(
+    messages: &HashMap<String, MessageTimes>,
+) -> Option<u128> {
+    if messages.is_empty() {
+        return None;
+    }
+
     let total = messages.iter().fold(0, |total, (_, times)| {
         if let Some(sent) = times.sent {
             if let Some(received) = times.received {
@@ -206,7 +212,7 @@ fn calculate_message_delivery_average_time(messages: &HashMap<String, MessageTim
         total
     });
 
-    total / (messages.len() as u128)
+    Some(total / (messages.len() as u128))
 }
 
 fn calculate_lost_messages(messages: &HashMap<String, MessageTimes>) -> usize {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -66,6 +66,10 @@ impl MetricsReport {
             lost_messages,
         }
     }
+
+    pub fn any_error(&self) -> bool {
+        self.http_errors_per_request.iter().any(|&(_, n)| n > 0)
+    }
 }
 
 impl Metrics {

--- a/src/text.rs
+++ b/src/text.rs
@@ -13,8 +13,10 @@ pub fn create_progress_bar(text: impl Into<Cow<'static, str>>, size: u64) -> Pro
     let progress_style = ProgressStyle::default_bar()
         .template("{prefix:>12.cyan.bold}: [{bar:57}] {pos}/{len}")
         .progress_chars("=> ");
+
     let progress_bar = ProgressBar::new(size);
     progress_bar.set_style(progress_style);
     progress_bar.set_prefix(text);
+
     progress_bar
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -502,7 +502,7 @@ fn create_user(user_params: UserParams) -> impl futures::Future<Output = Option<
 pub async fn create_desired_users(config: &Configuration, tx: Sender<Event>) {
     let users_to_create = config.user_count;
 
-    let mut current_users = load_users(config.users_filename.clone());
+    let mut servers_to_current_users = load_users(config.users_filename.clone());
 
     let mut users = vec![];
     let progress_bar = create_progress_bar(
@@ -517,11 +517,19 @@ pub async fn create_desired_users(config: &Configuration, tx: Sender<Event>) {
         .await
         .unwrap();
 
-    let _actual_users = current_users.get_available_users(homeserver_url.clone());
+    let current_users = servers_to_current_users.get_available_users(&homeserver_url);
 
-    let actual_user_count = _actual_users.map(|users| users.available).unwrap_or(0);
+    let current_user_count = current_users.map(|users| users.available).unwrap_or(0);
 
-    let futures = (actual_user_count..(users_to_create + actual_user_count)).map(|i| {
+    progress_bar.println(format!(
+        "{} users currently available for server '{}', creating new {} for a total of {}",
+        current_user_count,
+        config.homeserver_url,
+        users_to_create,
+        current_user_count + users_to_create
+    ));
+
+    let futures = (current_user_count..(users_to_create + current_user_count)).map(|i| {
         create_user(UserParams {
             server: homeserver_url.clone(),
             progress_bar: progress_bar.clone(),
@@ -545,15 +553,15 @@ pub async fn create_desired_users(config: &Configuration, tx: Sender<Event>) {
 
     progress_bar.finish_and_clear();
 
-    current_users.add_user(
+    servers_to_current_users.add_user(
         homeserver_url.clone(),
         SavedUserState {
-            available: config.user_count + actual_user_count,
+            available: config.user_count + current_user_count,
             friendships: vec![],
         },
     );
 
-    save_users(&current_users, config.users_filename.clone());
+    save_users(&servers_to_current_users, config.users_filename.clone());
 }
 
 #[cfg(test)]

--- a/src/user.rs
+++ b/src/user.rs
@@ -562,6 +562,8 @@ pub async fn create_desired_users(config: &Configuration, tx: Sender<Event>) {
     );
 
     save_users(&servers_to_current_users, config.users_filename.clone());
+
+    tx.send(Event::Finish).await.expect("Finish event sent");
 }
 
 #[cfg(test)]

--- a/src/users_state.rs
+++ b/src/users_state.rs
@@ -20,8 +20,8 @@ pub struct SavedUsers {
 }
 
 impl SavedUsers {
-    pub fn get_available_users(&self, server: String) -> Option<&SavedUserState> {
-        self.users.get(&server)
+    pub fn get_available_users(&self, server: &str) -> Option<&SavedUserState> {
+        self.users.get(server)
     }
 
     pub fn add_user(&mut self, key: String, value: SavedUserState) {
@@ -49,11 +49,9 @@ pub fn load_users(file: String) -> SavedUsers {
         };
     }
 
-    let file_content = std::fs::read_to_string(file).unwrap();
+    let file_content = std::fs::read_to_string(file).expect("cannot read file '{file}'");
 
-    let res: SavedUsers = serde_json::from_str(&file_content).unwrap();
-
-    res
+    serde_json::from_str::<SavedUsers>(&file_content).expect("cannot parse file content '{file}'")
 }
 
 #[cfg(test)]

--- a/users.json
+++ b/users.json
@@ -1,7 +1,7 @@
 {
   "users": {
     "synapse.decentraland.io": {
-      "available": 3003,
+      "available": 3015,
       "friendships": []
     },
     "matrix.decentraland.zone": {

--- a/users.json
+++ b/users.json
@@ -1,5 +1,9 @@
 {
   "users": {
+    "synapse.decentraland.io": {
+      "available": 3003,
+      "friendships": []
+    },
     "matrix.decentraland.zone": {
       "available": 200,
       "friendships": []

--- a/users.json
+++ b/users.json
@@ -5,7 +5,7 @@
       "friendships": []
     },
     "matrix.decentraland.zone": {
-      "available": 200,
+      "available": 3200,
       "friendships": []
     }
   }


### PR DESCRIPTION
- Added `Metrics#run` call when running command to create users to run the read events thread and avoid buffer getting blocked
- Added report when finishing creating users to publish whether errors where triggered
- Minor refactor of `message_delivery_average_time` to an from a `u128` to an `Option<u128>` when no message was sent during the execution (useful for setup tasks)
- Changing `unwrap` to `expect` for a more descriptive error
- Added linkers recommended by zero2prod to make build process faster
- Minor refactor of `String` to `&str` in the `SavedUsers#get_available_users` method argument
