### PR TITLE
fix: update syncing user through user notifier

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -1,7 +1,7 @@
 use crate::report::Report;
 use crate::user::MessageType;
 use matrix_sdk::locks::RwLock;
-use matrix_sdk::ruma::OwnedRoomId;
+use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId};
 use matrix_sdk::HttpError;
 use serde::Serialize;
 use std::sync::Arc;
@@ -34,6 +34,7 @@ pub enum UserRequest {
 #[derive(Debug)]
 pub enum UserNotifications {
     NewChannel(OwnedRoomId),
+    NewSyncedUser(OwnedUserId),
 }
 
 #[derive(Debug)]

--- a/src/events.rs
+++ b/src/events.rs
@@ -35,6 +35,7 @@ pub enum UserRequest {
 pub enum UserNotifications {
     NewChannel(OwnedRoomId),
     NewSyncedUser(OwnedUserId),
+    UserLoggedOut(OwnedUserId),
 }
 
 #[derive(Debug)]

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -116,7 +116,7 @@ impl Simulation {
             mpsc::channel::<UserNotifications>(100);
 
         let context = Arc::new(Context {
-            syncing_users: RwLock::new(self.get_syncing_users().await),
+            syncing_users: RwLock::new(Vec::new()),
             config: self.config.clone(),
             notifier: tx.clone(),
             user_notifier: user_notification_sender.clone(),

--- a/src/user.rs
+++ b/src/user.rs
@@ -242,7 +242,8 @@ impl User {
                 log::debug!("--- user '{}' going to start interaction", self.localpart);
                 if ticks_to_live <= &0 {
                     // it's time to log out
-                    self.log_out(cancel_sync.clone()).await;
+                    self.log_out(cancel_sync.clone(), &context.user_notifier)
+                        .await;
                 } else {
                     match pick_random_action(
                         context.config.simulation.probability_to_act,
@@ -266,7 +267,10 @@ impl User {
                             }
                         },
                         SocialAction::AddFriend => self.add_friend(context).await,
-                        SocialAction::LogOut => self.log_out(cancel_sync.clone()).await,
+                        SocialAction::LogOut => {
+                            self.log_out(cancel_sync.clone(), &context.user_notifier)
+                                .await
+                        }
                         SocialAction::UpdateStatus => self.update_status().await,
                         SocialAction::CreateChannel => {
                             self.create_channel(
@@ -448,11 +452,27 @@ impl User {
     }
 
     /// Log out user and append new char to the localpart string so next iteration is a new user.
-    async fn log_out(&mut self, cancel_sync: Sender<bool>) {
+    async fn log_out(
+        &mut self,
+        cancel_sync: Sender<bool>,
+        user_notifier: &UserNotificationsSender,
+    ) {
         log::debug!("user '{}' act => {}", self.localpart, "LOG OUT");
         cancel_sync.send(true).await.expect("channel open");
         self.state = State::LoggedOut;
         self.localpart += "_";
+        let user_id = self.id().await;
+        if let Some(user_id) = user_id {
+            user_notifier
+                .send(UserNotifications::UserLoggedOut(user_id))
+                .await
+                .expect("channel to be open");
+        } else {
+            log::debug!(
+                "user '{}' doesn't have user_id to send to log out",
+                self.localpart
+            );
+        }
     }
 
     async fn update_status(&self) {
@@ -462,11 +482,12 @@ impl User {
 
     async fn pick_friend(&self, context: &Context) -> Option<OwnedUserId> {
         let mut rng: StdRng = rand::SeedableRng::from_entropy(); // allow use it with threads
+        let synced_users = context.syncing_users.read().await;
+        let synced_users_vec = synced_users.iter().collect::<Vec<_>>();
         loop {
-            let synced_users = context.syncing_users.read().await;
-            let friend_id = synced_users.choose(&mut rng)?;
+            let friend_id = synced_users_vec.choose(&mut rng)?;
             if friend_id.localpart() != self.localpart {
-                return Some(friend_id.clone());
+                return Some(friend_id.to_owned().to_owned());
             }
         }
     }


### PR DESCRIPTION
### Issue: 
- users cannot add a friend because of context. Due to #81, the context is global for all users so, in the first ticks, the `syncing_users` field is 0. 

### Solution:
- This PR adds a new event to communicate when a user is synced by the `user_notifier` and updates the `syncing_users` field in the context. This `user_notifier`, until now handled the channel creation to update the context. 