### PR TITLE
feat: add weights to actions and pre-simulation actions

### DIFF
--- a/configuration.toml
+++ b/configuration.toml
@@ -15,6 +15,7 @@ channels_per_user = 5
 channels_load = true
 allow_get_channel_members = false
 presence_enabled = false
+channels_to_join = ["help", "test2010"]
 
 [requests]
 retry_enabled = true

--- a/configuration.toml
+++ b/configuration.toml
@@ -17,5 +17,16 @@ allow_get_channel_members = false
 presence_enabled = false
 channels_to_join = ["help", "test2010"]
 
+[action_weights]
+add_friend = 0
+send_channel_message = 5
+send_dm_message = 0
+log_out = 0
+update_status = 0
+create_channel = 0
+join_channel = 0
+leave_channel = 0
+get_channel_members = 0
+
 [requests]
 retry_enabled = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,7 +38,7 @@ use matrix_sdk::ruma::{
         AnyMessageLikeEventContent,
     },
     presence::PresenceState,
-    OwnedRoomId, OwnedUserId, RoomId, UserId,
+    OwnedRoomId, OwnedUserId, RoomId, RoomOrAliasId, ServerName, UserId,
 };
 use matrix_sdk::{
     config::{RequestConfig, SyncSettings},
@@ -364,6 +364,16 @@ impl Client {
                     .await;
             }
         }
+    }
+
+    pub async fn join_channel(&self, channel_alias: String, server_name: String) {
+        log::debug!("join_channel by alias {}", channel_alias);
+        let client = &self.inner;
+        let channel_alias = format!("#{channel_alias}:{server_name}");
+        let room_alias =
+            <&RoomOrAliasId>::try_from(channel_alias.as_str()).unwrap();
+        let server_name = <&ServerName>::try_from(server_name.as_str()).unwrap();
+        client.join_room_by_id_or_alias(room_alias, &[server_name.into()]).await;
     }
 
     pub async fn get_channel_members(&self, room_id: &RoomId) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,7 +38,7 @@ use matrix_sdk::ruma::{
         AnyMessageLikeEventContent,
     },
     presence::PresenceState,
-    OwnedRoomId, OwnedUserId, RoomId, RoomOrAliasId, ServerName, UserId,
+    OwnedRoomId, OwnedUserId, RoomId, RoomOrAliasId, UserId,
 };
 use matrix_sdk::{
     config::{RequestConfig, SyncSettings},

--- a/src/client.rs
+++ b/src/client.rs
@@ -366,14 +366,20 @@ impl Client {
         }
     }
 
-    pub async fn join_channel(&self, channel_alias: String, server_name: String) {
-        log::debug!("join_channel by alias {}", channel_alias);
+    pub async fn join_channel(&self, channel_name: String) {
         let client = &self.inner;
-        let channel_alias = format!("#{channel_alias}:{server_name}");
-        let room_alias =
-            <&RoomOrAliasId>::try_from(channel_alias.as_str()).unwrap();
-        let server_name = <&ServerName>::try_from(server_name.as_str()).unwrap();
-        client.join_room_by_id_or_alias(room_alias, &[server_name.into()]).await;
+        let user_homeserver = self.user_id().unwrap().server_name();
+        let channel_alias = format!("#{channel_name}:{user_homeserver}");
+        let room_alias = <&RoomOrAliasId>::try_from(channel_alias.as_str()).unwrap();
+
+        log::debug!("join_channel by alias {}", room_alias);
+        let result = client
+            .join_room_by_id_or_alias(room_alias, &[user_homeserver.into()])
+            .await;
+
+        if let Err(err) = result {
+            log::debug!("Failed to join channel! {:?}", err);
+        }
     }
 
     pub async fn get_channel_members(&self, room_id: &RoomId) {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -94,6 +94,7 @@ pub struct Config {
     pub simulation: Simulation,
     pub requests: Requests,
     pub feature_flags: FeatureFlags,
+    pub action_weights: ActionWeights,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -102,6 +103,19 @@ pub struct FeatureFlags {
     pub allow_get_channel_members: bool,
     pub presence_enabled: bool,
     pub channels_to_join: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ActionWeights {
+    pub add_friend: usize,
+    pub send_channel_message: usize,
+    pub send_dm_message: usize,
+    pub log_out: usize,
+    pub update_status: usize,
+    pub create_channel: usize,
+    pub join_channel: usize,
+    pub leave_channel: usize,
+    pub get_channel_members: usize,
 }
 
 impl Config {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -101,6 +101,7 @@ pub struct FeatureFlags {
     pub channels_load: bool,
     pub allow_get_channel_members: bool,
     pub presence_enabled: bool,
+    pub channels_to_join: Vec<String>,
 }
 
 impl Config {
@@ -128,6 +129,7 @@ impl Config {
             .set_default("feature_flags.channels_load", true)?
             .set_default("feature_flags.allow_get_channel_members", false)?
             .set_default("feature_flags.presence_enabled", true)?
+            .set_default::<&str, Vec<String>>("feature_flags.channels_to_join", vec![])?
             .build()?;
 
         log::debug!("Config: {:#?}", config);

--- a/src/events.rs
+++ b/src/events.rs
@@ -56,6 +56,7 @@ pub enum SyncEvent {
     MessageReceived(OwnedRoomId, String, RoomType),
     ChannelCreated(OwnedRoomId),
     GetChannelMembers(OwnedRoomId),
+    JoinChannel(String),
 }
 
 #[derive(Default)]

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -126,7 +126,7 @@ impl Progress for QuietProgress {
 pub fn create_progress(ticks: usize, max_users: usize) -> Box<dyn Progress> {
     let is_ci = env::var("CI").is_ok();
     match is_ci {
-        true => Box::new(QuietProgress::default()),
+        true => Box::<QuietProgress>::default(),
         false => Box::new(SimulationProgress::new(ticks, max_users)),
     }
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -128,6 +128,7 @@ impl Simulation {
         println!("server: {:#?}", self.config.server);
         println!("simulation config: {:#?}", self.config.simulation);
         println!("feature flags config: {:#?}", self.config.feature_flags);
+        println!("action weights config: {:?}", self.config.action_weights);
 
         self.progress.start();
         // channel used to share events from users to the Event Collector

--- a/src/user.rs
+++ b/src/user.rs
@@ -392,6 +392,7 @@ impl User {
                 self.get_channel_members(room_id, SocialAction::GetChannelMembers)
                     .await
             }
+            SyncEvent::JoinChannel(channel_name) => self.join_channel_alias(channel_name, ctx.config.server.homeserver.clone()).await,
             _ => {}
         }
     }
@@ -472,6 +473,9 @@ impl User {
         }
     }
 
+    async fn join_channel_alias(&self, channel_name: String, server_name: String) {
+        self.client.join_channel(channel_name, server_name).await;
+    }
     async fn pick_channel(&self, context: &Context) -> Option<OwnedRoomId> {
         let room_type = RoomType::Channel;
         let user_channels = match &self.state {

--- a/src/user.rs
+++ b/src/user.rs
@@ -392,7 +392,7 @@ impl User {
                 self.get_channel_members(room_id, SocialAction::GetChannelMembers)
                     .await
             }
-            SyncEvent::JoinChannel(channel_name) => self.join_channel_alias(channel_name, ctx.config.server.homeserver.clone()).await,
+            SyncEvent::JoinChannel(channel_name) => self.join_channel_alias(channel_name).await,
             _ => {}
         }
     }
@@ -473,9 +473,10 @@ impl User {
         }
     }
 
-    async fn join_channel_alias(&self, channel_name: String, server_name: String) {
-        self.client.join_channel(channel_name, server_name).await;
+    async fn join_channel_alias(&self, channel_name: String) {
+        self.client.join_channel(channel_name).await;
     }
+
     async fn pick_channel(&self, context: &Context) -> Option<OwnedRoomId> {
         let room_type = RoomType::Channel;
         let user_channels = match &self.state {


### PR DESCRIPTION
## Description

In order to test big channels, it introduces pre-simulation actions like join to certain channels and an improvement o how to pick actions. 

Now it uses a weighted distribution instead of a percentage for each action.


### To do before the merge

- review default weights
- add workflow config for weights